### PR TITLE
Fix bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -32,3 +32,4 @@ jobs:
         message: 'Update VERSION'
         add: 'djetson-flash --force'
         tag: '${{ steps.tag_action.outputs.tag }} --force'
+        tag_push: '--force'


### PR DESCRIPTION
EndBug/add-and-commit@v9 no longer deletes and recreates existing tags. Force pushing the tag to fix the workflow.

Broken job: https://github.com/pgils/docker-jetson-flash/runs/5651370132?check_suite_focus=true