### PR TITLE
Fix ci bump version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -12,6 +12,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
     -
       uses: actions/checkout@v4


### PR DESCRIPTION
allow update of VERSION by `bump-version` workflow with default limited GITHUB_TOKEN permissions.